### PR TITLE
assignment 1

### DIFF
--- a/1-26-2024
+++ b/1-26-2024
@@ -1,0 +1,61 @@
+/Text Index/
+db.student.createIndex({name: "text", description: "text"},
+{
+"createdCollectionAutomatically" : false,
+"numIndexesBefore" : 1,
+"numIndexsAfter" : 2,
+"ok": 1
+})
+  then give db.student.getindexes()
+/*o/p 
+[
+  { v: 2, key: { id: 1 }, name: '_id' },
+  { v: 2, key: { student_id: 223344 }, name: 'student_id_223344' },
+  { v: 2, key: { student_id: 777777 }, name: 'student_id_777777' },
+  { v: 2, key: { student_id: 1 }, name: 'student_id_1' },
+  {
+    v: 2,
+    key: { score: '2dsphere' },
+    name: 'score_2dsphere',
+    '2dsphereIndexVersion': 3
+  },
+  {
+    v: 2,
+    key: { _fts: 'text', _ftsx: 1 },
+    name: 'name_text_description_text',
+    weights: { description: 1, name: 1 },
+    default_language: 'english',
+    language_override: 'language',
+    textIndexVersion: 3
+  }
+] 
+*/
+    //HashIndex
+db.student.createIndex({_id: "hashed"})
+>_id_hashed
+db.student.getIndexes()
+/*o/p:
+[
+  { v: 2, key: { id: 1 }, name: '_id' },
+  { v: 2, key: { student_id: 223344 }, name: 'student_id_223344' },
+  { v: 2, key: { student_id: 777777 }, name: 'student_id_777777' },
+  { v: 2, key: { student_id: 1 }, name: 'student_id_1' },
+  {
+    v: 2,
+    key: { score: '2dsphere' },
+    name: 'score_2dsphere',
+    '2dsphereIndexVersion': 3
+  },
+  {
+    v: 2,
+    key: { _fts: 'text', _ftsx: 1 },
+    name: 'name_text_description_text',
+    weights: { description: 1, name: 1 },
+    default_language: 'english',
+    language_override: 'language',
+    textIndexVersion: 3
+  },
+  { v: 2, key: { _id: 'hashed' }, name: '_id_hashed' }
+]*/
+Footer
+© 


### PR DESCRIPTION
1.Text Index:In MongoDB, text indexing enables querying string content within a collection. This feature allows for searching any field containing string content or an array of strings. Each collection can have only one text index, which can be combined with other fields in a compound index.
The syntax to create a text index is as follows: 'db.collection.createIndex({ field: "text" })'.
<img width="808" alt="Screenshot 2024-03-25 at 6 28 24 PM" src="https://github.com/Priyankaparisa/ADV-database-design/assets/157556942/b7517e82-58d7-4a7c-b2d6-094a65b398f9">
2.MultiKeyIndex:In MongoDB, multikey indexes are utilized to index array values within fields. When you index a field containing an array, MongoDB automatically generates separate indexes for each individual value within that array. These multikey indexes facilitate efficient searching of documents containing arrays by matching their elements. MongoDB dynamically decides whether to create a multikey index based on the presence of array values in the indexed field, eliminating the need for explicit specification.
The syntax to create a multikey index is as follows: 'db.collection.createIndex({ field: 1 })'.
<img width="808" alt="Screenshot 2024-03-25 at 6 33 58 PM" src="https://github.com/Priyankaparisa/ADV-database-design/assets/157556942/da5cb510-7e17-412c-8417-c2ee760456a2">
3.Hash Index:A hash index in MongoDB is employed to store entries with the hashed values of the indexed field, typically the _id field in most collections. This index type is particularly useful for achieving even data distribution across a shared cluster. By hashing keys, MongoDB ensures data partitioning across the cluster.
The syntax for creating a hash index is:' db.collection.createIndex({ _id: "hashed" })'.
<img width="808" alt="Screenshot 2024-03-25 at 6 35 03 PM" src="https://github.com/Priyankaparisa/ADV-database-design/assets/157556942/1925957b-801a-468e-ab92-979f664617e9">
4.Wildcard index:In MongoDB, you can create indexes either on individual fields or a set of fields. When indexing a set of fields, it's referred to as a wildcard index. Typically, wildcard indexes exclude the _id field, but you can explicitly include it if needed. MongoDB permits the creation of multiple wildcard indexes within a collection. These indexes support queries for unknown or arbitrary fields.
The syntax to create a wildcard index is: db.collection.createIndex({ "field.$**": 1 }).
<img width="808" alt="Screenshot 2024-03-25 at 6 36 18 PM" src="https://github.com/Priyankaparisa/ADV-database-design/assets/157556942/13d41f42-fab5-4f38-a266-0ff8cffc06b7">

